### PR TITLE
Fix timetable urls in cfp page

### DIFF
--- a/assets/js/timetable/component/Day.jsx
+++ b/assets/js/timetable/component/Day.jsx
@@ -31,7 +31,7 @@ export default function Day(props: Props) {
   const className = classNames('day', `day-${props.day}`);
   return (
     <div className={className}>
-      <h2 className="title">Day {props.day}</h2>
+      <h2 className="title" id={`day-${props.day}`}>Day {props.day}</h2>
       {renderRow(props)}
     </div>
   );

--- a/assets/pages/cfp/index.jinja
+++ b/assets/pages/cfp/index.jinja
@@ -16,7 +16,7 @@
             before our deadline {{data.topics.deadline}}. The volunteers in our
             Program Committee had a hard time to shortlist them to fit in
             <span class="link">
-              <a href="/schedule">our agenda.</a>
+              <a href="{{ data.site.basePath }}/schedule">our agenda.</a>
             </span>
           </p>
           <p>Here is the list of the accepted CFP topics, along with some invited sessions &amp; confirmed sponsor sessions:</p>
@@ -35,7 +35,7 @@
           </ul> <!-- cpf-results -->
           <p></p>
           <p>If your topic is not selected, don't worry. You may still share your topic in our <b>Unconference Session</b> at
-            <span class="link"><a href="/schedule/#day-2"> of Day 2 (Saturday)</a></span>.
+            <span class="link"><a href="{{ data.site.basePath }}/schedule/#day-2"> of Day 2 (Saturday)</a></span>.
           </p>
           <p>
             <a class="waves-effect waves-light z-depth-2 btn"


### PR DESCRIPTION
/2017/schedule/#day-2 does not really scroll to day 2 of timetable even though I have already added id='day-2' in h2 element of Day component.

Please advise.